### PR TITLE
Fix round zero bugs

### DIFF
--- a/app/lib/definitions.ts
+++ b/app/lib/definitions.ts
@@ -61,6 +61,7 @@ export type DrawInfo = {
     fixtures: Match[];
     byes: ByeTeam[];
     selectedRoundId: number;
+    selectedSeasonId: number;
     filterTeams: TeamData[];
 }
 

--- a/app/lib/nrl-draw-utils.tsx
+++ b/app/lib/nrl-draw-utils.tsx
@@ -48,8 +48,6 @@ export function getMaxPoints(losses: number, draws: number) {
 
     const perfectSeasonPts = WIN_POINTS * MATCHES;
 
-    console.log(perfectSeasonPts);
-
     const pointsLost = perfectSeasonPts - (WIN_POINTS * losses) - draws;
 
     return pointsLost + (WIN_POINTS * byes);

--- a/app/lib/nrl-draw-utils.tsx
+++ b/app/lib/nrl-draw-utils.tsx
@@ -1,6 +1,6 @@
 import RoundFixture from '../ui/fixture/round-fixture';
 import { DrawInfo, Match, TeamData } from './definitions';
-import { getCurrentYear, NUMS } from './utils';
+import { CURRENTYEAR, NUMS } from './utils';
 
 /**
  * Construct the data for a team (statistics, team name, theme key)
@@ -24,16 +24,35 @@ export function constructTeamData(teams: Array<TeamData>) {
                 'points difference': 0,
                 points: 0,
                 noByePoints: 0,
-                maxPoints: 0,
+                maxPoints: getMaxPoints(0, 0)
             },
             name: team.name,
             theme: {
                 key: team.theme.key
-            },
+            }
         });
     }
 
     return teamList;
+}
+
+/**
+ * Get a team's maximum points
+ *
+ * @param {number} losses
+ * @param {number} draws
+ * @returns {number}
+ */
+export function getMaxPoints(losses: number, draws: number) {
+    const { BYES: byes, WIN_POINTS, MATCHES } = NUMS;
+
+    const perfectSeasonPts = WIN_POINTS * MATCHES;
+
+    console.log(perfectSeasonPts);
+
+    const pointsLost = perfectSeasonPts - (WIN_POINTS * losses) - draws;
+
+    return pointsLost + (WIN_POINTS * byes);
 }
 
 /**
@@ -51,15 +70,7 @@ export function constructTeamStats(
     teams: Array<TeamData>,
     modifiable: boolean,
 ) {
-    const { BYES: byes, WIN_POINTS, MATCHES, ROUNDS } = NUMS;
-
-    const getMaxPoints = (losses: number, draws: number) => {
-        const perfectSeasonPts = WIN_POINTS * MATCHES;
-
-        const pointsLost = perfectSeasonPts - (WIN_POINTS * losses) - draws;
-
-        return pointsLost + (WIN_POINTS * byes);
-    };
+    const { WIN_POINTS } = NUMS;
 
     const updateStats = (team: TeamData, teamScore: number, oppScore: number) => {
         team.stats.played += 1;
@@ -77,7 +88,7 @@ export function constructTeamStats(
 
     for (const round of seasonDraw) {
         // Do not count stats for games not started or finals games
-        if ((!modifiable && round.selectedRoundId > currentRoundNo) || round.selectedRoundId > ROUNDS) {
+        if (round.selectedRoundId > currentRoundNo) {
             break;
         }
 
@@ -86,15 +97,23 @@ export function constructTeamStats(
                 return bye.teamNickName === team.name;
             })[0];
 
-            byeTeam.stats.byes += 1;
-            byeTeam.stats.points = (WIN_POINTS * byeTeam.stats.wins) + byeTeam.stats.drawn +
-                (WIN_POINTS * byeTeam.stats.byes);
-            byeTeam.stats.noByePoints = byeTeam.stats.points - (WIN_POINTS * byeTeam.stats.byes);
+            const playedRoundFixtures = round.fixtures.filter((fixture) => {
+                return fixture.matchMode !== 'Pre';
+            });
+
+            // If a fixture has been played (or is being played) for a particular round,
+            // give the bye team their points
+            if (playedRoundFixtures.length) {
+                byeTeam.stats.byes += 1;
+                byeTeam.stats.points = (WIN_POINTS * byeTeam.stats.wins) + byeTeam.stats.drawn +
+                    (WIN_POINTS * byeTeam.stats.byes);
+                byeTeam.stats.noByePoints = byeTeam.stats.points - (WIN_POINTS * byeTeam.stats.byes);
+            }
         }
 
         for (const fixture of round.fixtures) {
             const { matchMode, homeTeam, awayTeam, roundTitle, matchCentreUrl } = fixture;
-            const currentYear = getCurrentYear();
+            const currentYear = CURRENTYEAR;
 
             // If match not started and on ladder page break away
             if (matchMode === 'Pre' && !modifiable) {
@@ -198,7 +217,7 @@ export function getRoundFixtures(
                 winningTeam={winningTeam}
                 ladder={ladder}
                 isFinalsFootball={isFinalsFootball}
-                modifiable={modifiable}
+                modifiable={modifiable && fixture.matchMode === 'Pre'}
                 modifiedFixtureCb={modifiedFixtureCb}
             />
         );

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -67,13 +67,14 @@ export function getOrdinalNumber(cardinalNo: number) {
     }
 }
 
+export let CURRENTYEAR: Number = new Date(Date.now()).getFullYear();
 /**
- * Get the current year
+ * Set the current year
  *
- * @returns {number} the current year (e.g. 2024)
+ * @param {number} the year from the draw (e.g. 2025)
  */
-export function getCurrentYear() {
-    return new Date(Date.now()).getFullYear();
+export function setCurrentYear(year: Number) {
+    CURRENTYEAR = year;
 }
 
 export const NUMS = Object.freeze({

--- a/app/ui/draw-fetcher.tsx
+++ b/app/ui/draw-fetcher.tsx
@@ -7,6 +7,7 @@ import SkeletonLadder from './skeletons/skeleton-ladder';
 import SkeletonMaxPoints from './skeletons/skeleton-max-points';
 import LadderPredictor from './ladder-predictor';
 import MaxPoints from './max-points';
+import { setCurrentYear } from '../lib/utils';
 
 export default function DrawFetcher({pageName}: {pageName: String}) {
     // Get the data
@@ -20,6 +21,9 @@ export default function DrawFetcher({pageName}: {pageName: String}) {
     if (isLoading) {
         return pageName === 'maxpoints' ? <SkeletonMaxPoints /> : <SkeletonLadder />;
     }
+
+    // Set the current year to be the year of the draw
+    setCurrentYear(seasonDraw[1].selectedSeasonId);
 
     // Load the UI component based on the pageName argument passed in
     switch (pageName) {

--- a/app/ui/fixture/input-score.tsx
+++ b/app/ui/fixture/input-score.tsx
@@ -1,4 +1,4 @@
-import { getCurrentYear } from '@/app/lib/utils';
+import { CURRENTYEAR } from '@/app/lib/utils';
 import { useEffect, useState } from 'react';
 import { useDebouncedCallback } from 'use-debounce';
 
@@ -17,7 +17,7 @@ export default function InputScore(
     const slug = matchSlug.split('/').filter(i => i)[4]; // homeTeam-v-awayTeam
     const teamsArray = slug.split('-v-'); // [homeTeam, awayTeam]
     const round = parseInt(matchSlug.split('/').filter(i => i)[3].replace('round-', '')); // round-x
-    const currentYear = getCurrentYear();
+    const currentYear = CURRENTYEAR;
 
     let predictions;
     let predictedTeamScore: number | undefined;

--- a/app/ui/fixture/round-fixture.tsx
+++ b/app/ui/fixture/round-fixture.tsx
@@ -121,7 +121,7 @@ function getMatchState(
     let commonClasses = 'flex flex-col md:flex-row gap-6 py-2 md:py-0 items-center justify-center w-full md:w-[34%]';
     const { matchMode, matchState, homeTeam, awayTeam, clock } = matchData;
 
-    if (matchState === 'FullTime' || matchMode === 'Live') {
+    if (modifiable || matchState === 'FullTime' || matchMode === 'Live') {
         commonClasses += ' pt-2';
 
         return (

--- a/app/ui/ladder-predictor.tsx
+++ b/app/ui/ladder-predictor.tsx
@@ -1,6 +1,6 @@
 import LadderRow from './ladder/ladder-row';
 import { TeamData, DrawInfo } from '../lib/definitions';
-import { getCurrentYear, NUMS } from '@/app/lib/utils';
+import { CURRENTYEAR, NUMS } from '@/app/lib/utils';
 import { getPageVariables, updateFixturesToShow } from '@/app/lib/nrl-draw-utils';
 import Fixtures from './fixture/fixtures';
 import { useState } from 'react';
@@ -15,7 +15,7 @@ export default function LadderPredictor({seasonDraw}: {seasonDraw: Array<DrawInf
     const { currentRoundNo, allTeams } = pageVariables;
     const { ROUNDS, FINALS_TEAMS } = NUMS;
 
-    const currentYear = getCurrentYear();
+    const currentYear = CURRENTYEAR;
 
     // Set current fixture round to last round if in finals football
     const inFinalsFootball = currentRoundNo > ROUNDS;
@@ -187,7 +187,7 @@ export default function LadderPredictor({seasonDraw}: {seasonDraw: Array<DrawInf
                 teamList={teams}
                 updateCallback={updateFixturesCb}
                 lastRoundNo={ROUNDS}
-                modifiable={roundIndex < currentRoundNo}
+                modifiable={true}
                 modifiedFixtureCb={updateAllTeams}
             />
         </div>


### PR DESCRIPTION
Bugs fixed:

- Predictor page
    - 7 byes for team with bye in round 27
    - Fixtures unmodifiable
    - Set “current year” correctly
- Live ladder page
    - Count bye points after one round fixture kicks off
- Max points page
    - Team stats maxPoints value not inited correctly